### PR TITLE
update docs; fix path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ saves
 .pytest_cache
 **/*.json
 **/*.csv
+build

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Fast, parallelizable simulations of Crazyflies with JAX and MuJoCo.
 ## Architecture
 
 <img src="/docs/img/architecture.png" width="75%" alt="Architecture">
+
+## Known Issues
+- `"RuntimeError: MUJOCO_PATH environment variable is not set"` upon installing the package: Try to not use `conda` with this project, as the `mujoco` install commonly fails with the mentioned error. Use another environment virtualization, e.g. `venv`, instead.
+- If using `zsh` don't forget to escape brackets when installing additional dependencies: `pip install .\[gpu\]`.

--- a/crazyflow/sim/core.py
+++ b/crazyflow/sim/core.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,7 @@ from crazyflow.utils import clone_body
 
 
 class Sim:
-    default_path = Path(__file__).parents[1] / "models/cf2/scene.xml"
+    default_path = Path(os.getcwd()) / "crazyflow" / "models" / "cf2" / "scene.xml"
 
     def __init__(
         self,


### PR DESCRIPTION
Relative path didn't work as `model/*.xml` files are not copied in `/build`. I changed path relative to the working dir, which fixes it for me in the scope of this repo.