### PR TITLE
Nominal yaw dynamics for crazyflow 0.0.2

### DIFF
--- a/crazyflow/sim/physics.py
+++ b/crazyflow/sim/physics.py
@@ -15,7 +15,7 @@ SYS_ID_PARAMS = {
     "acc": np.array([20.907574256269616, 3.653687545690674]),
     "roll_acc": np.array([-130.3, -16.33, 119.3]),
     "pitch_acc": np.array([-99.94, -13.3, 84.73]),
-    "yaw_acc": np.array([0.0, 0.0, 0.0]),
+    "yaw_acc": np.array([-60.0, -10.0, 120.0]),
 }
 
 

--- a/crazyflow/sim/sim.py
+++ b/crazyflow/sim/sim.py
@@ -156,8 +156,8 @@ class Sim:
         mode: str | None = "human",
         world: int = 0,
         default_cam_config: dict | None = None,
-        width: int = 640,
-        height: int = 480,
+        width: int = 1280,
+        height: int = 720,
     ) -> NDArray | None:
         if self.viewer is None:
             self.mj_model.vis.global_.offwidth = width


### PR DESCRIPTION
Add nominal yaw dynamics:
        "yaw_acc": np.array([-60.0, -10.0, 120.0]),
So that the controller can stabilize unknown disturbances from numerical issues. 
Otherwise, the drone starts spinning after a while, and we cannot control it.
Set default window size. Originally 480p, too small for visualization.
        width: int = 1280,
        height: int = 720,