### PR TITLE
Remove skip_headless function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,11 +33,6 @@ def device() -> str:
     return "cpu"
 
 
-def skip_headless():
-    if os.environ.get("DISPLAY") is None:
-        pytest.skip("DISPLAY is not set, skipping test in headless environment")
-
-
 # Marker for conditional skip in headless environments
 skip_if_headless = pytest.mark.skipif(
     os.environ.get("DISPLAY") is None,


### PR DESCRIPTION
Removed the skip_headless function to simplify headless test skipping.