### PR TITLE
Fix contacts and improve swarm spawning

### DIFF
--- a/crazyflow/sim/sim.py
+++ b/crazyflow/sim/sim.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from functools import partial, wraps
 from pathlib import Path
@@ -221,7 +223,10 @@ class Sim:
         self.mj_data.qpos[:] = self.mjx_data.qpos[world, :]
         self.mj_data.mocap_pos[:] = self.mjx_data.mocap_pos[world, :]
         self.mj_data.mocap_quat[:] = self.mjx_data.mocap_quat[world, :]
-        mujoco.mj_forward(self.mj_model, self.mj_data)
+        # mj_forward raises on contacts between two static bodies (e.g. drones welded to the world).
+        # We only need poses/lights for rendering
+        mujoco.mj_kinematics(self.mj_model, self.mj_data)
+        mujoco.mj_camlight(self.mj_model, self.mj_data)
         return self.viewer.render(mode)
 
     def seed(self, seed: int):
@@ -248,8 +253,12 @@ class Sim:
         name = "drone_fused" if self.fused_mjx_model else "drone"
         if (drone_body := drone_spec.body(name)) is None:
             raise ValueError("Drone body not found in drone spec")
+        drone_body.mocap = True
+        frame.attach_body(drone_body, "", ":0")  # Attach a single drone, then stamp out the swarm.
+        spec = self._replicate_drone(spec, f"{name}:0", drone_spec.meshdir)
         # Mocap bodies avoid the nv^2 cost of qM/qLD/efc_J. A single dummy slide joint keeps nv=1 so
-        # mjx.kinematics doesn't error on a zero-DOF mjx_model.
+        # mjx.kinematics doesn't error on a zero-DOF mjx_model. Added after _replicate_drone because
+        # to_xml() drops this geom-less body's mass/inertia (the result would fail to recompile).
         dummy = spec.worldbody.add_body()
         dummy.name = "_dummy"
         dummy.mass = 1e-6
@@ -257,19 +266,63 @@ class Sim:
         dummy_joint = dummy.add_joint()
         dummy_joint.name = "_dummy_joint"
         dummy_joint.type = mujoco.mjtJoint.mjJNT_SLIDE
-        drone_body.mocap = True
-        for i in range(self.n_drones):
-            frame.attach_body(drone_body, "", f":{i}")
         return spec
+
+    def _replicate_drone(
+        self, spec: mujoco.MjSpec, drone0_body: str, drone_meshdir: str
+    ) -> mujoco.MjSpec:
+        """Stamp the single attached drone body into ``n_drones`` instances by cloning its XML.
+
+        Avoids the O(n_drones^2) cost and per-instance mesh copies of repeated ``attach_body``.
+        Only element ``name``s are suffixed ``:0`` -> ``:i``, so meshes and static materials stay
+        shared. Dynamic materials are duplicated per drone.
+        """
+        # Name prefixes of the drone's "dynamic" materials which get per-copy materials
+        _DYN_MATERIAL = ("led",)
+        # Absolute meshdir so the serialized mesh file paths resolve when re-parsed from a string.
+        spec.meshdir = str((self.drone_path.parent / drone_meshdir).resolve())
+        root = ET.fromstring(spec.to_xml())
+        asset = root.find("asset")
+        body0 = root.find(f".//body[@name='{drone0_body}']")
+        frame = next(p for p in root.iter() if body0 in p)  # the body lives under the attach frame
+        dynamic = [m for m in asset.findall("material") if m.get("name").startswith(_DYN_MATERIAL)]
+        for i in range(1, self.n_drones):
+            body = copy.deepcopy(body0)
+            for el in body.iter():  # suffix unique names + dynamic-material refs. keep shared refs
+                if (name := el.get("name", "")).endswith(":0"):
+                    el.set("name", f"{name[:-2]}:{i}")
+                if (mat := el.get("material", "")).startswith(_DYN_MATERIAL):
+                    el.set("material", f"{mat[:-2]}:{i}")
+            frame.append(body)
+            for material in dynamic:
+                clone = copy.deepcopy(material)
+                clone.set("name", f"{material.get('name')[:-2]}:{i}")
+                asset.append(clone)
+        new_spec = mujoco.MjSpec.from_string(ET.tostring(root, encoding="unicode"))
+        new_spec.copy_during_attach = True  # write-only, re-apply after from_string() drops it
+        return new_spec
 
     def build_mjx_model(self, spec: mujoco.MjSpec) -> tuple[Any, Any, Model, Data]:
         """Build the MuJoCo model and data structures for the simulation."""
         mj_model = spec.compile()
+        self._unweld_drones(mj_model)
         mj_data = mujoco.MjData(mj_model)
         mjx_model = mjx.put_model(mj_model, device=self.device)
         mjx_data = mjx.put_data(mj_model, mj_data, device=self.device)
         mjx_data = jax.vmap(lambda _: mjx_data)(jnp.arange(self.n_worlds))
         return mj_model, mj_data, mjx_model, mjx_data
+
+    def _unweld_drones(self, mj_model: mujoco.MjModel):
+        """Relabel each drone as its own weld root so collisions are detected natively.
+
+        Drones are mocap bodies, so MuJoCo welds them all to the world (``weldid == 0``). MJX skips
+        collisions within a weld tree, leading to no drone contact being generated. A distinct weld
+        id per drone re-enables drone-drone/-floor/-object contacts without explicit ``<pair>``s.
+        """
+        base = "drone_fused" if self.fused_mjx_model else "drone"
+        for i in range(self.n_drones):
+            body_id = mj_model.body(f"{base}:{i}").id
+            mj_model.body_weldid[body_id] = body_id  # Each drone becomes its own weld root
 
     def build_step_fn(self) -> Callable[[SimData, int], SimData]:
         """Setup the chain of functions that are called in Sim.step().
@@ -544,11 +597,12 @@ def increment_steps(data: SimData) -> SimData:
 @jax.jit
 def contacts(geom_start: int, geom_count: int, data: Data) -> Array:
     """Filter contacts from MuJoCo data."""
-    geom1_valid = data.contact.geom1 >= geom_start
-    geom1_valid &= data.contact.geom1 < geom_start + geom_count
-    geom2_valid = data.contact.geom2 >= geom_start
-    geom2_valid &= data.contact.geom2 < geom_start + geom_count
-    return (data.contact.dist < 0) & (geom1_valid | geom2_valid)
+    contact = data._impl.contact
+    geom1_valid = contact.geom1 >= geom_start
+    geom1_valid &= contact.geom1 < geom_start + geom_count
+    geom2_valid = contact.geom2 >= geom_start
+    geom2_valid &= contact.geom2 < geom_start + geom_count
+    return (contact.dist < 0) & (geom1_valid | geom2_valid)
 
 
 @jax.jit

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -16,7 +16,7 @@ from crazyflow.control import Control
 from crazyflow.exception import ConfigError
 from crazyflow.sim import Dynamics, Sim
 from crazyflow.sim.data import ControlData, SimData
-from crazyflow.sim.sim import sync_sim2mjx
+from crazyflow.sim.sim import sync_sim2mjx, use_box_collision
 from crazyflow.sim.visualize import change_material
 
 if TYPE_CHECKING:
@@ -403,8 +403,114 @@ def test_contacts(dynamics: Dynamics):
     sim.reset()
     sim.step(10)  # Make sure the drone is on the ground
     contacts = sim.contacts()
+    # The contact buffer must contain the drone-floor contact
+    assert contacts.shape[-1] > 0, "Contact buffer should not be empty"
     assert jnp.all(contacts), "Drone should be in contact with the floor"
     sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("box_collision", [False, True])
+def test_contacts_between_drones(box_collision: bool):
+    """Two overlapping drones must register a contact.
+
+    Drones are mocap bodies that are all welded to the world. MuJoCo/MJX filter out collisions
+    between geoms welded into the same kinematic tree, so without explicit contact pairs no
+    drone-drone contact is ever generated.
+    """
+    sim = Sim(n_drones=2, control=Control.attitude, freq=500, device="cpu")
+    if box_collision:
+        use_box_collision(sim, True)
+    sim.reset()
+    states = sim.data.states
+    # Place both drones at the same position above the floor
+    pos = states.pos.at[:, 1, :].set(states.pos[:, 0, :]).at[..., 2].set(1.0)
+    sim.data = sim.data.replace(states=states.replace(pos=pos))
+    sim.data = sim.data.replace(core=sim.data.core.replace(mjx_synced=False))
+    assert jnp.any(sim.contacts("drone:0")), "Overlapping drones should be in contact"
+    assert jnp.any(sim.contacts("drone:1")), "Overlapping drones should be in contact"
+    sim.close()
+
+
+def _attach_obstacle(sim: Sim, pos: list[float], mocap: bool):
+    """Attach the minimal obstacle to the sim at ``pos``, mirroring downstream track loading."""
+    OBSTACLE_XML = """
+    <mujoco>
+    <worldbody>
+        <body name="obstacle">
+        <geom name="obstacle" type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+    </mujoco>
+    """
+    obstacle_spec = mujoco.MjSpec.from_string(OBSTACLE_XML)
+    frame = sim.spec.worldbody.add_frame()
+    obstacle = frame.attach_body(obstacle_spec.body("obstacle"), "", ":0")
+    obstacle.pos = pos
+    obstacle.mocap = mocap  # Mocap bodies (like the gates) are still welded to the world
+    sim.build_mjx()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("mocap", [True, False])
+def test_contacts_with_obstacle(mocap: bool):
+    """A drone placed inside an obstacle must register a contact.
+
+    Covers both a mocap obstacle (attached like the gates) and a static one. Both are welded to the
+    world just like the drones, so the collision is only detected if explicit contact pairs are
+    generated.
+    """
+    obstacle_pos = [0.0, 0.0, 1.0]
+    sim = Sim(control=Control.attitude, freq=500, device="cpu")
+    _attach_obstacle(sim, obstacle_pos, mocap=mocap)
+    sim.reset()
+    states = sim.data.states
+    pos = states.pos.at[..., :].set(jnp.array(obstacle_pos))
+    sim.data = sim.data.replace(states=states.replace(pos=pos))
+    sim.data = sim.data.replace(core=sim.data.core.replace(mjx_synced=False))
+    assert jnp.any(sim.contacts("drone:0")), "Drone should collide with the obstacle"
+    sim.close()
+
+
+@pytest.mark.unit
+def test_spec_copy_during_attach():
+    """sim.spec must copy bodies on attach so the same source body can be attached repeatedly."""
+    sim = Sim(n_drones=1, device="cpu")
+    box = mujoco.MjSpec.from_string('<mujoco><worldbody><body name="box"/></worldbody></mujoco>')
+    frame = sim.spec.worldbody.add_frame()
+    for i in range(2):  # copy_during_attach=False would move "box" out, returning None next lookup
+        frame.attach_body(box.body("box"), "", f":{i}")
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("fused", [False, True])
+@pytest.mark.parametrize("n_drones", [3, 17])
+def test_drone_meshes_shared(n_drones: int, fused: bool):
+    """The drone's visual meshes are shared across instances, not copied per drone.
+
+    Regression test for per-drone mesh duplication: ``attach_body`` copies the drone meshes for
+    every instance, which makes ``compile()`` memory and time grow linearly with ``n_drones``. With
+    sharing, the compiled mesh count is independent of the number of drones.
+    """
+    single = Sim(n_drones=1, fused_mjx_model=fused, device="cpu")
+    multi = Sim(n_drones=n_drones, fused_mjx_model=fused, device="cpu")
+    n_single, n_multi = single.mj_model.nmesh, multi.mj_model.nmesh
+    assert n_single > 0, "expected the drone to define visual meshes"
+    assert n_multi == n_single, f"mismatched mesh count: {single=} vs {multi=} for {n_drones=}"
+    # Every drone is still present as a distinct mocap body with the ``{body}:{i}`` naming.
+    assert multi.mj_model.nmocap == n_drones
+    body = "drone_fused" if fused else "drone"
+    ids = {multi.mj_model.body(f"{body}:{i}").id for i in range(n_drones)}
+    assert len(ids) == n_drones, "each drone must be a distinct body"
+    # Materials, unlike meshes, are kept per drone so each drone owns a distinct ``{mat}:{i}``
+    mat_ids = {
+        mujoco.mj_name2id(multi.mj_model, mujoco.mjtObj.mjOBJ_MATERIAL, f"led_bot:{i}")
+        for i in range(n_drones)
+    }
+    assert -1 not in mat_ids and len(mat_ids) == n_drones, "each drone needs its own material"
+    single.close()
+    multi.close()
 
 
 @pytest.mark.unit
@@ -477,20 +583,20 @@ def test_change_material(device: str, drone: str, mat_name: str):
     sim = Sim(n_drones=n_drones, drone=drone, device=device)
 
     drone_ids = np.array([0, 1], dtype=int)
-    rgba = 0.42 * np.ones((n_drones, 4), dtype=float)
-    emission = 0.42 * np.ones((n_drones,), dtype=float)
+    # Distinct values per drone to assert that each material gets its own value
+    rgba = np.stack([0.42 * np.ones(4), 0.73 * np.ones(4)])
+    emission = np.array([0.42, 0.73])
 
     change_material(sim, mat_name=mat_name, drone_ids=drone_ids, rgba=rgba, emission=emission)
 
     mj_model = sim.mj_model
     mat0 = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_MATERIAL, f"{mat_name}:0")
     mat1 = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_MATERIAL, f"{mat_name}:1")
-    expected_rgba = 0.42 * np.ones((4,), dtype=float)
-    expected_emission = 0.42
-    np.testing.assert_allclose(mj_model.mat_rgba[mat0], expected_rgba)
-    np.testing.assert_allclose(mj_model.mat_rgba[mat1], expected_rgba)
-    assert mj_model.mat_emission[mat0] == pytest.approx(expected_emission)
-    assert mj_model.mat_emission[mat1] == pytest.approx(expected_emission)
+    assert mat0 != mat1, "drones must not share the same material asset"
+    np.testing.assert_allclose(mj_model.mat_rgba[mat0], rgba[0])
+    np.testing.assert_allclose(mj_model.mat_rgba[mat1], rgba[1])
+    assert mj_model.mat_emission[mat0] == pytest.approx(emission[0])
+    assert mj_model.mat_emission[mat1] == pytest.approx(emission[1])
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Previous mocap memory optimizations broke the collision detection. MuJoCo does not detect contacts between static bodies that have the same root. Mocap bodies have the same root, because they are all welded with the same weld to the world frame. We now explicitly set the welds between mocaps and the world to unique IDs, registering them as collisions again.

While looking at this, I also realized the meshes of drones were getting copied for swarms. We switched to the CF21_B500 by default, which has a higher poly count mesh. In turn, this meant we could no longer fly swarms > 500. This patch also introduces memory and material sharing, allowing for >8K swarms now.

Since swarms are painfully slow to initialize, I improved the spec builder to avoid O(N^2) insertion costs, which fixes #43.

Tests cover collisions in more detail now, and should catch anything breaking the collision detection.