### PR TITLE
Fix gyroscopic precession sign: roll term (row 0) had the wrong sign

### DIFF
--- a/crazyflow/dynamics/first_principles/dynamics.py
+++ b/crazyflow/dynamics/first_principles/dynamics.py
@@ -139,14 +139,7 @@ def dynamics(
     rotor_vel_dot_rads = (
         rotor_vel_dot * rpm_to_rad if rotor_vel_dot is not None else xp.zeros_like(rotor_vel)
     )
-    # Gyroscopic torque -ω × h, with net rotor angular momentum h = h_z·ẑ.
-    # -ω × (0,0,h_z) = (-q·h_z, +p·h_z, 0): the roll and pitch rows have OPPOSITE signs.
-    # Here S = Σ mixing_matrix[-1]·ω_rotor is the yaw-torque-direction sum, i.e. the NEGATIVE of
-    # the physical spin direction (same row used, correctly, for the drag reaction torque and the
-    # z row below). Hence h_z = -prop_inertia·S, and substituting:
-    #   roll  (x) = -q·h_z = +prop_inertia·ang_vel[1]·S
-    #   pitch (y) = +p·h_z = -prop_inertia·ang_vel[0]·S
-    # The z row is the spin-up/down reaction torque.
+
     torque_inertia = prop_inertia * xp.stack(
         [
             ang_vel[..., 1] * xp.sum(mixing_matrix[..., -1, :] * rotor_vel_rads, axis=-1),
@@ -268,9 +261,7 @@ def symbolic_dynamics(
     rpm_to_rad = 2 * cs.pi / 60
     rotor_vel_rads = symbols.rotor_vel * rpm_to_rad
     rotor_vel_dot_rads = rotor_vel_dot * rpm_to_rad if model_rotor_vel else symbols.rotor_vel * 0.0
-    # Gyroscopic torque -ω × h (see dynamics() for the full derivation): the roll row is
-    # +ang_vel[1]·S and the pitch row is -ang_vel[0]·S (opposite signs), where S uses the
-    # yaw-torque-direction row (= -physical spin), so h_z = -prop_inertia·S.
+
     torque_inertia = prop_inertia * cs.vertcat(
         symbols.ang_vel[1] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),
         -symbols.ang_vel[0] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),

--- a/crazyflow/dynamics/first_principles/dynamics.py
+++ b/crazyflow/dynamics/first_principles/dynamics.py
@@ -139,9 +139,17 @@ def dynamics(
     rotor_vel_dot_rads = (
         rotor_vel_dot * rpm_to_rad if rotor_vel_dot is not None else xp.zeros_like(rotor_vel)
     )
+    # Gyroscopic torque -ω × h, with net rotor angular momentum h = h_z·ẑ.
+    # -ω × (0,0,h_z) = (-q·h_z, +p·h_z, 0): the roll and pitch rows have OPPOSITE signs.
+    # Here S = Σ mixing_matrix[-1]·ω_rotor is the yaw-torque-direction sum, i.e. the NEGATIVE of
+    # the physical spin direction (same row used, correctly, for the drag reaction torque and the
+    # z row below). Hence h_z = -prop_inertia·S, and substituting:
+    #   roll  (x) = -q·h_z = +prop_inertia·ang_vel[1]·S
+    #   pitch (y) = +p·h_z = -prop_inertia·ang_vel[0]·S
+    # The z row is the spin-up/down reaction torque.
     torque_inertia = prop_inertia * xp.stack(
         [
-            -ang_vel[..., 1] * xp.sum(mixing_matrix[..., -1, :] * rotor_vel_rads, axis=-1),
+            ang_vel[..., 1] * xp.sum(mixing_matrix[..., -1, :] * rotor_vel_rads, axis=-1),
             -ang_vel[..., 0] * xp.sum(mixing_matrix[..., -1, :] * rotor_vel_rads, axis=-1),
             xp.sum(mixing_matrix[..., -1, :] * rotor_vel_dot_rads, axis=-1),
         ],
@@ -260,8 +268,11 @@ def symbolic_dynamics(
     rpm_to_rad = 2 * cs.pi / 60
     rotor_vel_rads = symbols.rotor_vel * rpm_to_rad
     rotor_vel_dot_rads = rotor_vel_dot * rpm_to_rad if model_rotor_vel else symbols.rotor_vel * 0.0
+    # Gyroscopic torque -ω × h (see dynamics() for the full derivation): the roll row is
+    # +ang_vel[1]·S and the pitch row is -ang_vel[0]·S (opposite signs), where S uses the
+    # yaw-torque-direction row (= -physical spin), so h_z = -prop_inertia·S.
     torque_inertia = prop_inertia * cs.vertcat(
-        -symbols.ang_vel[1] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),
+        symbols.ang_vel[1] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),
         -symbols.ang_vel[0] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),
         cs.sum(mixing_matrix[-1, :] * rotor_vel_dot_rads),
     )

--- a/crazyflow/dynamics/first_principles/dynamics.py
+++ b/crazyflow/dynamics/first_principles/dynamics.py
@@ -139,7 +139,6 @@ def dynamics(
     rotor_vel_dot_rads = (
         rotor_vel_dot * rpm_to_rad if rotor_vel_dot is not None else xp.zeros_like(rotor_vel)
     )
-
     torque_inertia = prop_inertia * xp.stack(
         [
             ang_vel[..., 1] * xp.sum(mixing_matrix[..., -1, :] * rotor_vel_rads, axis=-1),
@@ -261,7 +260,6 @@ def symbolic_dynamics(
     rpm_to_rad = 2 * cs.pi / 60
     rotor_vel_rads = symbols.rotor_vel * rpm_to_rad
     rotor_vel_dot_rads = rotor_vel_dot * rpm_to_rad if model_rotor_vel else symbols.rotor_vel * 0.0
-
     torque_inertia = prop_inertia * cs.vertcat(
         symbols.ang_vel[1] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),
         -symbols.ang_vel[0] * cs.sum(mixing_matrix[-1, :] * rotor_vel_rads),


### PR DESCRIPTION
The propeller gyroscopic torque had the wrong sign on the **roll** axis (row 0 of `torque_inertia`), in both `dynamics` (numeric) and `symbolic_dynamics` in `crazyflow/dynamics/first_principles/dynamics.py`.

The gyroscopic torque is `-ω × h` with net rotor angular momentum `h = h_z·ẑ`, which gives `(-q·h_z, +p·h_z, 0)` — the roll and pitch rows must have **opposite** signs (it is a cross product). The code had them with the **same** leading sign (`-q·S`, `-p·S`), so exactly one row is wrong.

The subtlety is *which* row. `S = Σ mixing_matrix[-1]·ω_rotor` uses the yaw-torque-direction row, which is the **negative** of the physical spin direction (the same row that correctly signs the drag reaction and the z spin-up/down term). So `h_z = -prop_inertia·S`, and substituting:

```
roll  (x) = -q·h_z = +prop_inertia·ang_vel[1]·S   # code had a leading "-": the bug
pitch (y) = +p·h_z = -prop_inertia·ang_vel[0]·S   # already correct
```

The z (reaction) row is already correct, and is what pins the convention: it is consistent only with `spin = -mixing_matrix[-1]`. So the fix is to flip the sign of the **roll** row, leaving the pitch row unchanged.

Verified numerically against `-ω × h` to machine precision on all axes; `numeric == symbolic` still holds for `ang_vel_dot`. Only matters for non-negligible `prop_inertia` / larger quads during yaw-type maneuvers; negligible for a Crazyflie.

> Note: an earlier revision of this PR flipped the *pitch* row instead. That was incorrect — it left the roll bug in place and inverted the already-correct pitch term (roughly doubling the error). Now corrected to flip the roll row.
